### PR TITLE
Bug fix: clicking youtube.com will be handled by Media Extended

### DIFF
--- a/src/modules/media-info.ts
+++ b/src/modules/media-info.ts
@@ -189,6 +189,7 @@ export const getMediaInfo = async (
         return null;
       }
       break;
+    case "youtube.com":
     case "www.youtube.com":
     case "youtu.be":
       if (src.pathname === "/watch") {


### PR DESCRIPTION
Before this change, clicking `https://youtube.com/watch?` (without www)
will open the video in browser.

I notice this issue when I was using Obsidian on iOS. When I copy the Youtube link through the iOS share sheet, the URL doesn't contains the `www` prefix.