### PR TITLE
Updated title.ts : removes YouTube notifications

### DIFF
--- a/apps/app/src/web/title.ts
+++ b/apps/app/src/web/title.ts
@@ -7,7 +7,7 @@ export const titleParser: Record<MediaHost, (title: string) => string> = {
       /[-_]哔哩哔哩.+$|[-_]bilibili.+$|-(?:番剧|电影|纪录片|国创|电视剧|综艺)-.+/g,
       "",
     ),
-  youtube: (title) => title.replace(/ - YouTube$/, ""),
+  youtube: (title) => title.replace(/^\(\d+\) /, "").replace(/ - YouTube$/, ""),
   vimeo: (title) => title.replace(/ on Vimeo$/, ""),
   coursera: (title) => title.replace(/ \| Coursera$/, ""),
 };


### PR DESCRIPTION
Makes it so that when you save a screenshot (this is what bothered me), the screenshot's name doesn't include "(number) " which comes at the start of the title when logged in to YouTube. This makes the loading of the media slower.