### PR TITLE
Update link.internal.ts: patchLinktextOpen breaks internal link handlers of other plugins

### DIFF
--- a/apps/app/src/patch/link.internal.ts
+++ b/apps/app/src/patch/link.internal.ts
@@ -1,5 +1,5 @@
 import { around } from "monkey-around";
-import { type Workspace } from "obsidian";
+import { Workspace } from "obsidian";
 import type MxPlugin from "@/mx-main";
 import type { LinkEvent } from "./event";
 import { toPaneAction } from "./mod-evt";
@@ -12,7 +12,7 @@ export default function patchLinktextOpen(
   const plugin = this;
 
   this.register(
-    around(this.app.workspace, {
+    around(Workspace.prototype, {
       openLinkText: (next) =>
         async function (
           this: Workspace,


### PR DESCRIPTION
The `openLinkText` patch conflicts with other plugins with the same patch and breaks it.

To reproduce the error:

1. First enable Media Extended
2. Then enable No Dupe Leaves

In this case [No Dupe Leaves](https://github.com/scambier/obsidian-no-dupe-leaves/blob/f13956eee684f3ade4109741fd40012ebb0ac898/src/main.ts#L17) will not work properly. If you enable Media Extended later, both plugins work fine. The same problem occurs with the [PDF++](https://github.com/RyotaUshio/obsidian-pdf-plus/blob/f6f17514f1bf1e894a9e77aeea14f586b33bc356/src/patchers/workspace.ts#L13) plugin.