### PR TITLE
allow opening existing media notes, so I can append to them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ yarn-error.log*
 robots.txt
 sitemap.xml
 sitemap-0.xml
+
+packages/cm-language/**/*

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint src/ --ext .ts,.tsx --fix"
   },
   "devDependencies": {
-    "@codemirror/language": "../../packages/cm-language",
+    "@codemirror/language": "link:../../packages/cm-language",
     "@codemirror/state": "^6.0.0",
     "@codemirror/view": "^6.0.0",
     "@electron/remote": "^2.1.1",

--- a/apps/app/src/media-note/leaf-open/index.ts
+++ b/apps/app/src/media-note/leaf-open/index.ts
@@ -261,19 +261,33 @@ export class LeafOpener extends Component {
   }
 
   async openNote(
-    file: TFile,
-    newLeaf?: "split",
-    direction?: SplitDirection,
-  ): Promise<{ file: TFile; editor: Editor }>;
-  async openNote(
-    file: TFile,
-    newLeaf?: PaneType | boolean,
-  ): Promise<{ file: TFile; editor: Editor }>;
-  async openNote(
     note: TFile,
     newLeaf: PaneType | boolean = "split",
     direction: SplitDirection = "vertical",
   ): Promise<{ file: TFile; editor: Editor }> {
+    // Check for existing files with the same basename
+    const existingFiles = this.app.vault
+      .getFiles()
+      .filter((f) =>
+        f.basename === note.basename &&
+        f.extension === note.extension &&
+        f.path !== note.path,
+      );
+
+    if (existingFiles.length > 0) {
+      // const confirmation = await this.app.modal.confirm(
+      //   `Note "${note.basename}" already exists. Would you like to open and append to the existing note?`,
+      //   {
+      //     title: "Note Already Exists",
+      //   }
+      // );
+
+      // if (confirmation) {
+      // Use the existing note instead
+      note = existingFiles[0];
+      // }
+    }
+
     const opened = this.#getOpenedNote([note]);
     if (opened) {
       if (opened.getMode() !== "source") {

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "neverBuiltDependencies": [
       "electron"
     ]
+  },
+  "dependencies": {
+    "media-captions": "^0.0.18"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,15 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "!.next/cache/**"
+      ]
     },
     "dev": {
       "cache": false


### PR DESCRIPTION
chore: update package dependencies and media-note leaf component
update: allow apped new note to existing one. 

What did I fix:
![CleanShot 2025-02-05 at 16 43 46@2x](https://github.com/user-attachments/assets/2b5fa485-d81d-49f2-a63b-1237551374dc)

Current note taking will create a new note if we stopped watching video and open it in another session, which causes duplicated notes being taken in different files. This fix is intend to fix this but using existing note and append content to it.